### PR TITLE
patchelf: Optional logging, exception API

### DIFF
--- a/lib/patchelf/exceptions.rb
+++ b/lib/patchelf/exceptions.rb
@@ -1,0 +1,9 @@
+# encoding: ascii-8bit
+# frozen_string_literal: true
+
+require 'elftools/exceptions'
+
+module PatchELF
+  # Raised on an error during ELF modification.
+  class PatchError < ELFError ; end
+end

--- a/lib/patchelf/exceptions.rb
+++ b/lib/patchelf/exceptions.rb
@@ -5,5 +5,5 @@ require 'elftools/exceptions'
 
 module PatchELF
   # Raised on an error during ELF modification.
-  class PatchError < ELFError ; end
+  class PatchError < ELFTools::ELFError ; end
 end

--- a/lib/patchelf/patcher.rb
+++ b/lib/patchelf/patcher.rb
@@ -26,14 +26,6 @@ module PatchELF
       @logging = logging
     end
 
-    def log_or_raise(msg)
-      if @logging
-        PatchELF::Logger.warn(msg)
-      else
-        raise PatchELF::PatchError, msg
-      end
-    end
-
     # @return [String?]
     #   Get interpreter's name.
     # @example
@@ -167,6 +159,14 @@ module PatchELF
     end
 
     private
+
+    def log_or_raise(msg)
+      if @logging
+        PatchELF::Logger.warn(msg)
+      else
+        raise PatchELF::PatchError, msg
+      end
+    end
 
     def interpreter_
       segment = @elf.segment_by_type(:interp)


### PR DESCRIPTION
Introduces a generic PatchError exception that derives from
rbelftools's ELFError. Makes logging with PatchELF::Logger opt-outable.

Closes #12.