### PR TITLE
Introduce get/set rpath methods

### DIFF
--- a/lib/patchelf/patcher.rb
+++ b/lib/patchelf/patcher.rb
@@ -126,7 +126,23 @@ module PatchELF
     # Get runpath.
     # @return [String?]
     def runpath
-      @set[@rpath_sym] || runpath_
+      @set[@rpath_sym] || runpath_(@rpath_sym)
+    end
+
+    # Get rpath
+    # return [String?]
+    def rpath
+      @set[:rpath] || runpath_(:rpath)
+    end
+
+    # Set rpath
+    #
+    # Modify / set DT_RPATH of the given ELF.
+    # similar to runpath= except DT_RPATH is modifed/created in DYNAMIC segment.
+    # @param [String] rpath
+    # @macro note_apply
+    def rpath=(rpath)
+      @set[:rpath] = rpath
     end
 
     # Set runpath.
@@ -184,8 +200,8 @@ module PatchELF
     end
 
     # @return [String?]
-    def runpath_
-      tag_name_or_log(@rpath_sym, "Entry DT_#{@rpath_sym.to_s.upcase} not found.")
+    def runpath_(rpath_sym = :runpath)
+      tag_name_or_log(rpath_sym, "Entry DT_#{rpath_sym.to_s.upcase} not found.")
     end
 
     # @return [String?]

--- a/spec/patcher_spec.rb
+++ b/spec/patcher_spec.rb
@@ -109,6 +109,29 @@ describe PatchELF::Patcher do
     end
   end
 
+  describe 'rpath=' do
+    it 'overwrites rpath' do
+      patcher = get_patcher('rpath.elf')
+      patcher.rpath = 'o O' # picking different sym to avoid confusion
+      with_tempfile do |tmp|
+        patcher.save tmp
+        expect(described_class.new(tmp).rpath).to eq 'o O'
+      end
+    end
+
+    it 'writing to rpath leaves runpath untouched' do
+      patcher = get_patcher('runpath.elf')
+      patcher.rpath = 'o O'
+      with_tempfile do |tmp|
+        patcher.save tmp
+
+        saved_patcher = described_class.new(tmp)
+        expect(saved_patcher.runpath).to eq patcher.runpath
+        expect(saved_patcher.rpath).to eq 'o O'
+      end
+    end
+  end
+
   describe 'needed' do
     it 'combo' do
       patcher = get_patcher('pie.elf')


### PR DESCRIPTION
* Introduces methods to read/write to rpath.
* Disables `.use_rpath!`.
However removing `.use_rpath!` seems a bummer move from my side,
a good option maybe to just leave it there to keep compatibility for existing users.

* Related to Issue #19 

* ~Bump version~

P.S: due to time constraints went ahead and implemented the prolly clean solution.