### PR TITLE
new exceptions. MissingSegmentError, MissingTagError

### DIFF
--- a/lib/patchelf/exceptions.rb
+++ b/lib/patchelf/exceptions.rb
@@ -6,4 +6,8 @@ require 'elftools/exceptions'
 module PatchELF
   # Raised on an error during ELF modification.
   class PatchError < ELFTools::ELFError; end
+  # Raised when Dynamic Tag is missing
+  class MissingTagError < PatchError; end
+  # Raised on missing Program Header(segment)
+  class MissingSegmentError < PatchError; end
 end


### PR DESCRIPTION
`MissingSegmentError` is raised when a segment can't be located.
In this commit, it is raised when dynamic segment is not found.
`MissingTagError`  is raised when dynamic tags can't be located.

`PatchError` is a catchall exception,
It creates problem for who use patchelf.rb as library.
Having a little bit of distinction helps, for e.g, when
querying runpath, the user may want to distinguish between
corrupt ELF and missing case of runpath.

[An example of how we handle this ](https://github.com/Homebrew/brew/blob/f51e28072904da3e288097d8f6534e16a8552f24/Library/Homebrew/os/linux/elf.rb#L76-L78) :(
