### PR TITLE
Bump v1.3.0

### DIFF
--- a/lib/patchelf/version.rb
+++ b/lib/patchelf/version.rb
@@ -2,5 +2,5 @@
 
 module PatchELF
   # Current gem version.
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
PatchELF::Patcher#save accepts 'patchelf_compatible: true|false' as argument.

ELFs saved using `patchelf_compatible: true`,
is guaranteed(:crossed_fingers: ) to work like NixOS/patchelf.

2 new spec files added,
`syncthing` - a naughty go binary
`pef-compat.elf` - minimal elf with interpreter and runpath. 
   this is patchable using `patchelf_compatible: true`,  
without it `new_load_method` gently spews(; `NotImplementedError`



**P.S**:  idk when #28 will be merged,  as soon as it is merged please tag and release this version.
Thanks! 
