### PR TITLE
Pass CODECOV_TOKEN for coverage uploads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
           bundler-cache: true
 
       - name: Run tests
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bundle exec rake
 
       - name: Upload coverage results
@@ -37,6 +39,7 @@ jobs:
         with:
           files: coverage/coverage.xml
           disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   conclusion:
     needs: tests


### PR DESCRIPTION
Coverage uploads from protected branches require an upload token, so the codecov-action was failing with `Token required because branch is protected`.

Pass `secrets.CODECOV_TOKEN` to both the codecov-action upload step and the test run, matching the `ruby-macho` configuration.