### PR TITLE
Fix release lockfile drift and bump version to 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patchelf (1.6.0)
+    patchelf (1.6.1)
       elftools (>= 1.3)
       logger (~> 1)
 
@@ -81,7 +81,6 @@ DEPENDENCIES
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   bindata (2.5.1) sha256=53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58
-  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   elftools (1.3.1) sha256=9d46fca49a7d5e821b9c80127b19d59e8ce578bfaa17b99c8ff259222686aaf8
   json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
@@ -90,7 +89,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
-  patchelf (1.6.0)
+  patchelf (1.6.1)
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a

--- a/lib/patchelf/version.rb
+++ b/lib/patchelf/version.rb
@@ -2,5 +2,5 @@
 
 module PatchELF
   # Current gem version.
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end


### PR DESCRIPTION
The v1.6.0 release failed before upload because Dependabot added a Bundler 4.0.17 checksum while the lockfile remained pinned to Bundler 4.0.16. `bundle install` removed the mismatched checksum, causing Bundler's release clean-tree guard to abort.

Remove the injected checksum and bump to v1.6.1 because the immutable v1.6.0 tag cannot be reused.

The Dependabot behavior that introduced this checksum has been fixed upstream.