### PR TITLE
Freeze release dependencies and bump to 1.6.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    env:
+      BUNDLE_FROZEN: "true"
+
     permissions:
       contents: write
       id-token: write

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patchelf (1.6.1)
+    patchelf (1.6.2)
       elftools (>= 1.3)
       logger (~> 1)
 
@@ -89,7 +89,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
-  patchelf (1.6.1)
+  patchelf (1.6.2)
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a

--- a/lib/patchelf/version.rb
+++ b/lib/patchelf/version.rb
@@ -2,5 +2,5 @@
 
 module PatchELF
   # Current gem version.
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end


### PR DESCRIPTION
Set BUNDLE_FROZEN for the release job so Bundler cannot rewrite the
checksum-enabled lockfile based on how Bundler was installed.

Bump to 1.6.2 because the immutable v1.6.1 release failed before upload.